### PR TITLE
Add support for truffleruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,8 @@ matrix:
       env: WITH_RUBYGEMS=1.6.2
     - rvm: 2.5
       env: TEST_SUFFIX=-bundle
+    - rvm: 2.5
+      env: TEST_SUFFIX=-truffleruby
     - rvm: 1.8.7
     - rvm: 1.9.2
     - rvm: 1.9.3

--- a/bin/ruby_executable_hooks
+++ b/bin/ruby_executable_hooks
@@ -12,4 +12,14 @@ rescue LoadError
   warn "unable to load executable-hooks/hooks" if ENV.key?('ExecutableHooks_DEBUG')
 end unless $0.end_with?('/executable-hooks-uninstaller')
 
-eval File.read($0), binding, $0
+content = File.read($0)
+
+if
+  (index = content.index("\n#!ruby\n")) && index > 0
+then
+  skipped_content = content.slice!(0..index)
+  start_line = skipped_content.count("\n") + 1
+  eval content, binding, $0, start_line
+else
+  eval content, binding, $0
+end

--- a/lib/executable-hooks/wrapper.rb
+++ b/lib/executable-hooks/wrapper.rb
@@ -35,7 +35,7 @@ module ExecutableHooks
       bindir       = calculate_bindir(options)
       destination  = calculate_destination(bindir)
 
-      if File.exist?(wrapper_path) && !File.exist?(destination)
+      if File.exist?(wrapper_path)
         FileUtils.mkdir_p(bindir) unless File.exist?(bindir)
         # exception based on Gem::Installer.generate_bin
         raise Gem::FilePermissionError.new(bindir) unless File.writable?(bindir)

--- a/test-tf-truffleruby/truffleruby_comment_test.sh
+++ b/test-tf-truffleruby/truffleruby_comment_test.sh
@@ -1,0 +1,16 @@
+gem install executable-hooks-$(awk -F'"' '/VERSION/{print $2}' < lib/executable-hooks/version.rb).gem --development
+# match=/installed/
+
+gem install haml -v "4.0.7"    # match=/installed/
+haml_bin=$(which haml )
+head -n 1 $haml_bin            # match=/ruby_executable_hooks/
+
+## simulate truffleruby style binary with shell code mixed in
+## \043 - is a # ... somehow it breaks tf
+( head -n 1 $haml_bin; echo -e 'echo $HOME\n\043!ruby'; tail -n +2 $haml_bin ) > $haml_bin.new
+mv $haml_bin.new $haml_bin
+chmod +x $haml_bin
+
+haml _4.0.7_ -v                # match=/4.0.7/
+
+gem uninstall -x haml -v 4.0.7 # match=/Successfully uninstalled/


### PR DESCRIPTION
Should address rvm/rvm#4408

Truffleruby comes with binaries having both shell and ruby code, this change detects start of ruby code and if necessary skips the shell code part.