### PR TITLE
Avoid Ruby 2.7 warning

### DIFF
--- a/bin/ruby_executable_hooks
+++ b/bin/ruby_executable_hooks
@@ -14,9 +14,7 @@ end unless $0.end_with?('/executable-hooks-uninstaller')
 
 content = File.read($0)
 
-if
-  (index = content.index("\n#!ruby\n")) && index > 0
-then
+if (index = content.index("\n#!ruby\n")) && index > 0
   skipped_content = content.slice!(0..index)
   start_line = skipped_content.count("\n") + 1
   eval content, binding, $0, start_line


### PR DESCRIPTION
This PR changes a script in bin/ to not emit this warning (which I got when using it with Ruby 2.7)

  - warning: `if' at the end of line without an expression