### PR TITLE
Use Gem::Installer.at instead of Gem::Installer.new

### DIFF
--- a/lib/executable-hooks/regenerate_binstubs_command.rb
+++ b/lib/executable-hooks/regenerate_binstubs_command.rb
@@ -120,7 +120,8 @@ class RegenerateBinstubsCommand < Gem::Command
     cache_gem = File.join(org_gem_path, 'cache', spec.file_name)
     if File.exist? cache_gem
       puts "#{spec.name} #{spec.version}"
-      inst = Gem::Installer.at Dir[cache_gem].first, :wrappers => true, :force => true, :install_dir => org_gem_path, :bin_dir => options[:bin_dir]
+      installer_method = Gem::Installer.respond_to?(:at) ? :at : :new
+      inst = Gem::Installer.public_send installer_method, Dir[cache_gem].first, :wrappers => true, :force => true, :install_dir => org_gem_path, :bin_dir => options[:bin_dir]
       ExecutableHooksInstaller.bundler_generate_bin(inst)
     else
       false

--- a/lib/executable-hooks/regenerate_binstubs_command.rb
+++ b/lib/executable-hooks/regenerate_binstubs_command.rb
@@ -120,7 +120,7 @@ class RegenerateBinstubsCommand < Gem::Command
     cache_gem = File.join(org_gem_path, 'cache', spec.file_name)
     if File.exist? cache_gem
       puts "#{spec.name} #{spec.version}"
-      inst = Gem::Installer.new Dir[cache_gem].first, :wrappers => true, :force => true, :install_dir => org_gem_path, :bin_dir => options[:bin_dir]
+      inst = Gem::Installer.at Dir[cache_gem].first, :wrappers => true, :force => true, :install_dir => org_gem_path, :bin_dir => options[:bin_dir]
       ExecutableHooksInstaller.bundler_generate_bin(inst)
     else
       false


### PR DESCRIPTION
Using String as first argument to Gem::Installer.new is deprecated since [2015](https://github.com/rubygems/rubygems/commit/de3f8d0d) and removed in [2020](https://github.com/rubygems/rubygems/pull/3113).