### PR TITLE
Replace use of File.exists? by File.exist?

### DIFF
--- a/lib/executable-hooks/regenerate_binstubs_command.rb
+++ b/lib/executable-hooks/regenerate_binstubs_command.rb
@@ -128,7 +128,7 @@ class RegenerateBinstubsCommand < Gem::Command
   end
 
   def existing_gem_path(full_name)
-    expanded_gem_paths.find{|path| File.exists?(File.join(path, 'gems', full_name))}
+    expanded_gem_paths.find{|path| File.exist?(File.join(path, 'gems', full_name))}
   end
 
   def expanded_gem_paths


### PR DESCRIPTION
File.exists? was removed in Ruby 3.0.